### PR TITLE
Notify backend when MolSysViewer frontend is ready

### DIFF
--- a/molsysviewer/js/src/widget.ts
+++ b/molsysviewer/js/src/widget.ts
@@ -43,6 +43,17 @@ export default {
         // Crear el plugin una sola vez por elemento
         const pluginPromise = createMolSysViewer(el);
 
+        // Avisar al backend cuando el plugin esté inicializado para
+        // que pueda enviar los mensajes pendientes.
+        (async () => {
+            try {
+                await pluginPromise;
+                model.send({ event: "ready" });
+            } catch (error) {
+                console.error("[MolSysViewer] Error inicializando el plugin:", error);
+            }
+        })();
+
         // Logs de depuración por si acaso
         console.log("[MolSysViewer] widget render inicial");
 


### PR DESCRIPTION
## Summary
- emit a `ready` message from the widget once the Mol* plugin has finished initializing so pending backend messages get flushed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bba084a448326bd9ad722dcf51db7)