### PR TITLE
Add bootstrap script for codex setup

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# 1. Crear o actualizar el entorno Conda/Mamba desde environment.yml
+if ! conda env list | grep -q 'molsysviewer@uibcdf_3\.12'; then
+    conda env create -f environment.yml
+else
+    conda env update -f environment.yml --prune
+fi
+
+# 2. Activar el entorno y preparar Python.
+eval "$(conda shell.bash hook)"
+conda activate molsysviewer@uibcdf_3.12
+pip install --upgrade pip
+pip install -e .
+
+# 3. Instalar dependencias JS y construir el bundle del widget.
+pushd molsysviewer/js >/dev/null
+npm install
+npm run build
+popd >/dev/null
+
+echo "MolSysViewer listo para usarse."


### PR DESCRIPTION
## Summary
- add `scripts/bootstrap.sh` so the repo can be initialized with a single command
- script creates/updates the Conda env, installs the editable package, and builds the JS bundle

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bbeb5a3ac83269afb091a79247891)