### PR TITLE
Add loaded-structure tracking and cleanup

### DIFF
--- a/molsysviewer/js/src/structure.ts
+++ b/molsysviewer/js/src/structure.ts
@@ -1,13 +1,38 @@
 // src/structure.ts
 import { PluginContext } from "molstar/lib/mol-plugin/context";
+import { PluginStateObject as SO } from "molstar/lib/mol-plugin-state/objects";
+import { StateObjectRef } from "molstar/lib/mol-state";
+
+export interface LoadStructureOptions {
+    /** Referencia al nodo anterior que se debe eliminar antes de cargar. */
+    previous?: StateObjectRef;
+}
+
+export interface LoadedStructure {
+    /** Referencia al nodo raíz de los datos brutos. */
+    data: StateObjectRef<SO.Data.String | SO.Data.Binary | SO.Data.Blob>;
+    /** Referencia al nodo de la trayectoria (parseado). */
+    trajectory: StateObjectRef<SO.Molecule.Trajectory>;
+    /** Referencia opcional a la estructura creada por el preset. */
+    structure?: StateObjectRef<SO.Molecule.Structure>;
+}
+
+async function recyclePreviousNode(plugin: PluginContext, previous?: StateObjectRef) {
+    if (!previous) return;
+    const builder = plugin.build();
+    builder.delete(previous);
+    await builder.commit();
+}
 
 export async function loadStructureFromString(
     plugin: PluginContext,
     data: string,
     format: string = "pdb",
-    label?: string
-) {
-    // Crea el data node bruto
+    label?: string,
+    options?: LoadStructureOptions
+): Promise<LoadedStructure> {
+    await recyclePreviousNode(plugin, options?.previous);
+
     const raw = await plugin.builders.data.rawData({
         data,
         label: label ?? "Structure from string",
@@ -19,18 +44,27 @@ export async function loadStructureFromString(
     const trajectory = await plugin.builders.structure.parseTrajectory(raw, format as any);
 
     // Aplica el preset por defecto (representación bonita estándar)
-    await plugin.builders.structure.hierarchy.applyPreset(trajectory, "default");
+    const preset = await plugin.builders.structure.hierarchy.applyPreset(trajectory, "default");
+
+    return {
+        data: raw.ref,
+        trajectory: trajectory.ref,
+        structure: preset?.structure?.ref,
+    };
 }
 
 export async function loadStructureFromUrl(
     plugin: PluginContext,
     url: string,
     format?: string,
-    label?: string
-) {
+    label?: string,
+    options?: LoadStructureOptions
+): Promise<LoadedStructure> {
+    await recyclePreviousNode(plugin, options?.previous);
+
     // Descarga la estructura (texto) desde la URL
-    const data = await plugin.builders.data.download(
-        { url, isBinary: false },
+    const dataNode = await plugin.builders.data.download(
+        { url, isBinary: false, label },
         { state: { isGhost: true } }
     );
 
@@ -40,9 +74,15 @@ export async function loadStructureFromUrl(
         (url.split(".").pop() ?? "pdb"); // "pdb", "cif", "mmcif", etc.
 
     const trajectory = await plugin.builders.structure.parseTrajectory(
-        data,
+        dataNode,
         guessedFormat as any
     );
 
-    await plugin.builders.structure.hierarchy.applyPreset(trajectory, "default");
+    const preset = await plugin.builders.structure.hierarchy.applyPreset(trajectory, "default");
+
+    return {
+        data: dataNode.ref,
+        trajectory: trajectory.ref,
+        structure: preset?.structure?.ref,
+    };
 }


### PR DESCRIPTION
## Summary
- add `LoadStructureOptions`/`LoadedStructure` to expose the references created when loading structures and ensure previous nodes are recycled via `plugin.build()`
- update the widget controller to store the `LoadedStructure`, reuse it for subsequent loads, and fully delete the previous scene data when clearing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d578252348326b770bcf5ab8b8a35)