### PR TITLE
Clarify README about viewer bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,14 @@ MolSysViewer uses:
 
 - **Python** for the API and widget interface  
 - **TypeScript + Mol\*** for rendering  
-- **esbuild** for bundling the widget  
-- **anywidget** as the Jupyter integration layer  
+- **esbuild** for bundling the widget
+- **anywidget** as the Jupyter integration layer
 
 The JS bundle (`viewer.js`) is generated automatically during packaging and is
-not committed to the repository.
+tracked in the repository (it carries the `@generated` banner) so that users of
+the published wheels/conda packages never need a Node.js toolchain. The bundle
+should not be edited by hand; rebuild it from the TypeScript sources under
+`js/src/` instead.
 
 Build the JS bundle manually for development:
 


### PR DESCRIPTION
## Summary
- clarify that the generated `viewer.js` bundle is tracked in the repo
- explain why it is committed and remind contributors to rebuild from `js/src`

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d5fa97e3c83269d483ae570eed868)