### PR TITLE
Add network link cylinders and Python API

### DIFF
--- a/molsysviewer/js/src/shapes.ts
+++ b/molsysviewer/js/src/shapes.ts
@@ -12,9 +12,14 @@ import { ColorNames } from "molstar/lib/mol-util/color/names";
 
 import { Vec3 } from "molstar/lib/mol-math/linear-algebra";
 
+import { OrderedSet } from "molstar/lib/mol-data/int/ordered-set";
+
+import { Structure, Unit, ElementIndex } from "molstar/lib/mol-model/structure";
+
 import { Mesh } from "molstar/lib/mol-geo/geometry/mesh/mesh";
 import { MeshBuilder } from "molstar/lib/mol-geo/geometry/mesh/mesh-builder";
 import { addSphere } from "molstar/lib/mol-geo/geometry/mesh/builder/sphere";
+import { addCylinder, BasicCylinderProps } from "molstar/lib/mol-geo/geometry/mesh/builder/cylinder";
 
 import { Shape } from "molstar/lib/mol-model/shape";
 import { ShapeRepresentation } from "molstar/lib/mol-repr/shape/representation";
@@ -299,6 +304,382 @@ export async function addTransparentSpheresFromPython(
             alpha,
         } as any,
         { tags: tag ?? "molsysviewer:spheres" }
+    );
+
+    await PluginCommands.State.Update(plugin, {
+        state: plugin.state.data,
+        tree: builder,
+        options: { doNotLogTiming: true },
+    });
+
+    return node.ref;
+}
+
+// ------------------------------------------------------------------
+// Network links (cylinders between point pairs)
+// ------------------------------------------------------------------
+
+type NetworkLinkColorMode = "link" | "pocket" | "chain";
+type NetworkLinkMode = "coordinates" | "atom-indices";
+
+const DefaultLinkPalette = [
+    ColorNames.blue,
+    ColorNames.orange,
+    ColorNames.green,
+    ColorNames.red,
+    ColorNames.purple,
+    ColorNames.gray,
+    ColorNames.pink,
+    ColorNames.brown,
+];
+
+export interface NetworkLinkSpec {
+    start: [number, number, number];
+    end: [number, number, number];
+    radius: number;
+    color: number;
+    pocketId?: string | number;
+    chainId?: string;
+    label?: string;
+}
+
+interface NetworkLinksData {
+    links: NetworkLinkSpec[];
+    alpha: number;
+    radialSegments: number;
+    name: string;
+    tag?: string;
+}
+
+const NetworkLinksParams = {
+    ...Mesh.Params,
+};
+type NetworkLinksParams = typeof NetworkLinksParams;
+type NetworkLinksProps = PD.Values<NetworkLinksParams>;
+
+function buildNetworkLinkMesh(data: NetworkLinksData, _props: NetworkLinksProps, prev?: Mesh): Mesh {
+    const state = MeshBuilder.createState(256, 128, prev);
+    const start = Vec3();
+    const end = Vec3();
+
+    for (let i = 0, il = data.links.length; i < il; i++) {
+        const link = data.links[i];
+        state.currentGroup = i;
+        Vec3.set(start, link.start[0], link.start[1], link.start[2]);
+        Vec3.set(end, link.end[0], link.end[1], link.end[2]);
+
+        const cylinderProps: BasicCylinderProps = {
+            radiusTop: link.radius,
+            radiusBottom: link.radius,
+            radialSegments: Math.max(3, Math.floor(data.radialSegments)),
+        };
+
+        addCylinder(state, start, end, 1, cylinderProps);
+    }
+
+    return MeshBuilder.getMesh(state);
+}
+
+function getNetworkLinksName(count: number) {
+    if (count === 0) return "Network Links (empty)";
+    if (count === 1) return "Network Link";
+    return `${count} Network Links`;
+}
+
+function getNetworkLinksShape(
+    _ctx: RuntimeContext,
+    data: NetworkLinksData,
+    _props: NetworkLinksProps,
+    shape?: Shape<Mesh>
+) {
+    const mesh = buildNetworkLinkMesh(data, _props, shape?.geometry);
+    const getColor = (groupId: number) => Color(data.links[groupId].color);
+    const getSize = (groupId: number) => data.links[groupId].radius;
+    const getLabel = (groupId: number) =>
+        data.links[groupId].label ?? `Link ${groupId} (r = ${data.links[groupId].radius.toFixed(2)})`;
+
+    return Shape.create(data.name, data, mesh, getColor, getSize, getLabel);
+}
+
+const NetworkLinksVisuals = {
+    mesh: (
+        _ctx: RepresentationContext,
+        _getParams: RepresentationParamsGetter<NetworkLinksData, NetworkLinksParams>
+    ) => ShapeRepresentation(getNetworkLinksShape, Mesh.Utils),
+};
+
+type NetworkLinksRepresentation = Representation<NetworkLinksData, NetworkLinksParams>;
+
+function NetworkLinksRepresentation(
+    ctx: RepresentationContext,
+    getParams: RepresentationParamsGetter<NetworkLinksData, NetworkLinksParams>
+): NetworkLinksRepresentation {
+    return Representation.createMulti(
+        "NetworkLinks",
+        ctx,
+        getParams,
+        Representation.StateBuilder,
+        NetworkLinksVisuals as unknown as Representation.Def<NetworkLinksData, NetworkLinksParams>
+    );
+}
+
+const NetworkLinksTransformParams = {
+    data: PD.Value<NetworkLinksData>(undefined as any),
+    props: PD.Value<NetworkLinksProps>(undefined as any),
+};
+
+type NetworkLinksTransformParams = typeof NetworkLinksTransformParams;
+
+export const NetworkLinks3D = MSVTransform({
+    name: "molsysviewer-network-links-3d",
+    display: { name: "Network Links" },
+    from: SO.Root,
+    to: SO.Shape.Representation3D,
+    params: NetworkLinksTransformParams,
+})({
+    canAutoUpdate() {
+        return true;
+    },
+    apply({ params }, plugin: PluginContext) {
+        return Task.create("Network Links", async ctx => {
+            const repr = NetworkLinksRepresentation(
+                { webgl: plugin.canvas3d?.webgl, ...plugin.representation.structure.themes },
+                () => NetworkLinksParams
+            );
+
+            await repr.createOrUpdate(params.props, params.data).runInContext(ctx);
+            repr.setState({ alphaFactor: params.data.alpha });
+
+            return new SO.Shape.Representation3D({ repr, sourceData: params.data }, { label: params.data.name });
+        });
+    },
+    update({ b, newParams }, _plugin: PluginContext) {
+        return Task.create("Network Links", async ctx => {
+            await b.data.repr.createOrUpdate(newParams.props, newParams.data).runInContext(ctx);
+            b.data.repr.setState({ alphaFactor: newParams.data.alpha });
+            b.data.sourceData = newParams.data;
+            return StateTransformer.UpdateResult.Updated;
+        });
+    },
+});
+
+type CoordinatePair = [number, number, number, number, number, number] | [[number, number, number], [number, number, number]];
+
+export interface NetworkLinkOptions {
+    mode?: NetworkLinkMode;
+    coordinate_pairs?: CoordinatePair[];
+    atom_pairs?: [number, number][];
+    radii?: number | number[];
+    colors?: number | number[];
+    pocket_ids?: Array<string | number>;
+    chain_ids?: string[];
+    color_mode?: NetworkLinkColorMode;
+    alpha?: number;
+    radial_segments?: number;
+    tag?: string;
+}
+
+function normalizeCoordinatePair(entry: CoordinatePair): { start: [number, number, number]; end: [number, number, number] } | null {
+    if (Array.isArray(entry[0])) {
+        const start = (entry as [[number, number, number], [number, number, number]])[0];
+        const end = (entry as [[number, number, number], [number, number, number]])[1];
+        if (start.length === 3 && end.length === 3) {
+            return {
+                start: [Number(start[0]), Number(start[1]), Number(start[2])],
+                end: [Number(end[0]), Number(end[1]), Number(end[2])],
+            };
+        }
+        return null;
+    }
+
+    if (Array.isArray(entry) && entry.length === 6) {
+        return {
+            start: [Number(entry[0]), Number(entry[1]), Number(entry[2])],
+            end: [Number(entry[3]), Number(entry[4]), Number(entry[5])],
+        };
+    }
+
+    return null;
+}
+
+function expandToList<T>(value: T | T[] | undefined, count: number, cast: (v: T) => T, fallback: T): T[] {
+    if (Array.isArray(value)) {
+        if (value.length === count) return value.map(cast);
+        console.warn(`[MolSysViewer] Esperaba ${count} valores pero recibí ${value.length}. Se reutilizará el primero.`);
+        return Array(count).fill(cast(value[0]));
+    }
+    return Array(count).fill(cast((value ?? fallback) as T));
+}
+
+function prepareColorLookup(keys: Array<string | number>, fallback: number) {
+    const paletteCount = DefaultLinkPalette.length;
+    const colorByKey = new Map<string | number, number>();
+    keys.forEach((key, idx) => {
+        if (!colorByKey.has(key)) {
+            colorByKey.set(key, DefaultLinkPalette[idx % paletteCount]);
+        }
+    });
+    return (key?: string | number) => (key !== undefined ? colorByKey.get(key) ?? fallback : fallback);
+}
+
+function buildUnitLookup(structure: Structure) {
+    const map = new Map<ElementIndex, { unit: Unit; elementIndex: ElementIndex }>();
+    for (const unit of structure.units) {
+        const { elements } = unit;
+        const count = OrderedSet.size(elements);
+        for (let i = 0; i < count; i++) {
+            const element = OrderedSet.getAt(elements, i) as ElementIndex;
+            map.set(element, { unit, elementIndex: element });
+        }
+    }
+    return map;
+}
+
+function getChainId(unit: Unit, elementIndex: ElementIndex) {
+    if (!Unit.isAtomic(unit)) return undefined;
+    const chainIndex = unit.getChainIndex(elementIndex);
+    return unit.model.atomicHierarchy.chains.label_asym_id.value(chainIndex);
+}
+
+function buildLinksFromCoordinates(options: NetworkLinkOptions): NetworkLinkSpec[] {
+    const pairs = options.coordinate_pairs ?? [];
+    const normalizedPairs = pairs
+        .map(normalizeCoordinatePair)
+        .filter((p): p is { start: [number, number, number]; end: [number, number, number] } => p !== null);
+
+    const count = normalizedPairs.length;
+    if (count === 0) return [];
+
+    const radii = expandToList<number>(options.radii, count, Number, 0.2);
+    const chainIds = expandToList<string>(options.chain_ids, count, String, "");
+    const pocketIds = expandToList<string | number>(options.pocket_ids, count, v => v, "");
+    const colorMode: NetworkLinkColorMode = options.color_mode ?? "link";
+    const colors = expandToList<number>(options.colors, count, Number, ColorNames.skyblue);
+
+    const paletteLookup = prepareColorLookup(colorMode === "pocket" ? pocketIds : chainIds, colors[0]);
+
+    return normalizedPairs.map((pair, idx) => {
+        const linkColor =
+            colorMode === "link"
+                ? colors[idx]
+                : paletteLookup(colorMode === "pocket" ? pocketIds[idx] : chainIds[idx]);
+        return {
+            start: pair.start,
+            end: pair.end,
+            radius: radii[idx],
+            color: linkColor,
+            pocketId: pocketIds[idx],
+            chainId: chainIds[idx] || undefined,
+        };
+    });
+}
+
+function buildLinksFromAtoms(structure: Structure, options: NetworkLinkOptions): NetworkLinkSpec[] {
+    const pairs = options.atom_pairs ?? [];
+    const count = pairs.length;
+    if (count === 0) return [];
+
+    const lookup = buildUnitLookup(structure);
+    const radii = expandToList<number>(options.radii, count, Number, 0.2);
+    const pocketIds = expandToList<string | number>(options.pocket_ids, count, v => v, "");
+    const colorMode: NetworkLinkColorMode = options.color_mode ?? "link";
+    const colors = expandToList<number>(options.colors, count, Number, ColorNames.skyblue);
+
+    const positionsStart = Vec3();
+    const positionsEnd = Vec3();
+
+    const chainIdList: string[] = [];
+    const specs: NetworkLinkSpec[] = [];
+
+    for (let i = 0; i < count; i++) {
+        const [a, b] = pairs[i];
+        const locA = lookup.get(a as ElementIndex);
+        const locB = lookup.get(b as ElementIndex);
+        if (!locA || !locB) {
+            console.warn(`[MolSysViewer] atom_pairs[${i}] no coincide con átomos de la estructura`);
+            continue;
+        }
+
+        locA.unit.conformation.position(locA.elementIndex, positionsStart);
+        locB.unit.conformation.position(locB.elementIndex, positionsEnd);
+
+        const chainId = getChainId(locA.unit, locA.elementIndex) ?? getChainId(locB.unit, locB.elementIndex);
+        chainIdList.push(chainId ?? "");
+
+        specs.push({
+            start: [positionsStart[0], positionsStart[1], positionsStart[2]],
+            end: [positionsEnd[0], positionsEnd[1], positionsEnd[2]],
+            radius: radii[i],
+            color: colors[i],
+            pocketId: pocketIds[i],
+            chainId: chainId ?? undefined,
+        });
+    }
+
+    if (specs.length === 0) return [];
+
+    if (colorMode === "chain") {
+        const paletteLookup = prepareColorLookup(chainIdList, colors[0]);
+        specs.forEach((spec, idx) => {
+            spec.color = paletteLookup(chainIdList[idx]);
+        });
+    } else if (colorMode === "pocket") {
+        const paletteLookup = prepareColorLookup(pocketIds, colors[0]);
+        specs.forEach(spec => {
+            spec.color = paletteLookup(spec.pocketId);
+        });
+    }
+
+    return specs;
+}
+
+export async function addNetworkLinksFromPython(plugin: PluginContext, options: NetworkLinkOptions) {
+    const mode: NetworkLinkMode = options.mode ?? (options.atom_pairs ? "atom-indices" : "coordinates");
+    const radialSegments = Math.max(3, Math.floor(options.radial_segments ?? 16));
+    const alpha = options.alpha ?? 1.0;
+
+    let links: NetworkLinkSpec[] = [];
+    let name = "Network Links";
+
+    if (mode === "atom-indices") {
+        const structureRef = plugin.managers.structure.hierarchy.current.structures.slice(-1)[0];
+        const structure = structureRef?.cell.obj?.data as Structure | undefined;
+        if (!structure) {
+            console.warn("[MolSysViewer] add_network_links sin estructura cargada");
+            return undefined;
+        }
+        links = buildLinksFromAtoms(structure, options);
+        name = getNetworkLinksName(links.length);
+    } else {
+        links = buildLinksFromCoordinates(options);
+        name = getNetworkLinksName(links.length);
+    }
+
+    if (links.length === 0) {
+        console.warn("[MolSysViewer] add_network_links sin datos válidos");
+        return undefined;
+    }
+
+    const data: NetworkLinksData = {
+        links,
+        alpha,
+        radialSegments,
+        name,
+        tag: options.tag,
+    };
+
+    const props: NetworkLinksProps = {
+        ...PD.getDefaultValues(NetworkLinksParams),
+    };
+
+    const builder = plugin.state.data.build();
+    const node = builder.toRoot().apply(
+        NetworkLinks3D,
+        {
+            data,
+            props,
+        } as any,
+        { tags: options.tag ?? "molsysviewer:network-links" }
     );
 
     await PluginCommands.State.Update(plugin, {

--- a/molsysviewer/js/src/widget.ts
+++ b/molsysviewer/js/src/widget.ts
@@ -20,7 +20,13 @@ import { OrderedSet } from "molstar/lib/mol-data/int/ordered-set";
 import { SortedArray } from "molstar/lib/mol-data/int/sorted-array";
 import { StateObjectRef } from "molstar/lib/mol-state";
 
-import { addTransparentSphereFromPython, addTransparentSpheresFromPython, TransparentSphereSpec } from "./shapes";
+import {
+    addNetworkLinksFromPython,
+    addTransparentSphereFromPython,
+    addTransparentSpheresFromPython,
+    NetworkLinkOptions,
+    TransparentSphereSpec,
+} from "./shapes";
 import { addPocketSurfaceFromPython, PocketSurfaceOptions } from "./pocket-surface";
 import {
     LoadedStructure,
@@ -126,6 +132,9 @@ class MolSysViewerController {
 
                 case "add_pocket_surface":
                     await this.handleAddPocketSurface(msg as AddPocketSurfaceMessage);
+                    break;
+                case "add_network_links":
+                    await this.handleAddNetworkLinks(msg as AddNetworkLinksMessage);
                     break;
 
                 case "update_visibility":
@@ -249,6 +258,15 @@ class MolSysViewerController {
             await addPocketSurfaceFromPython(this.plugin, options);
         } catch (err) {
             console.error("[MolSysViewer] Error creando pocket surface", err);
+        }
+    }
+
+    private async handleAddNetworkLinks(msg: AddNetworkLinksMessage) {
+        const options = msg.options ?? {};
+        try {
+            await addNetworkLinksFromPython(this.plugin, options);
+        } catch (err) {
+            console.error("[MolSysViewer] Error creando network links", err);
         }
     }
 
@@ -458,6 +476,11 @@ type AddPocketSurfaceMessage = {
     options?: PocketSurfaceOptions;
 };
 
+type AddNetworkLinksMessage = {
+    op: "add_network_links";
+    options?: NetworkLinkOptions;
+};
+
 type LoadStructureMessage = {
     op: "load_structure_from_string" | "load_pdb_string";
     data?: string;
@@ -510,6 +533,7 @@ type ViewerMessage =
     AddSphereMessage |
     AddAlphaSphereSetMessage |
     AddPocketSurfaceMessage |
+    AddNetworkLinksMessage |
     LoadStructureMessage |
     LoadMolSysPayloadMessage |
     LoadStructureFromUrlMessage |

--- a/molsysviewer/shapes/__init__.py
+++ b/molsysviewer/shapes/__init__.py
@@ -2,6 +2,7 @@
 
 from .spheres import SphereShapes
 from .pocket_surfaces import PocketSurfaces
+from .links import LinkShapes
 
 
 class ShapesManager:
@@ -17,6 +18,7 @@ class ShapesManager:
         # Submódulos especializados
         self.spheres = SphereShapes(view)
         self.pockets = PocketSurfaces(view)
+        self.links = LinkShapes(view)
 
     # Atajos de conveniencia para mantener la API actual:
     #
@@ -54,5 +56,12 @@ class ShapesManager:
     ):
         return self.spheres.add_set_alpha_spheres(*args, **kwargs)
 
+    def add_links(
+        self,
+        *args,
+        **kwargs,
+    ):
+        return self.links.add_links(*args, **kwargs)
 
-__all__ = ["ShapesManager", "SphereShapes", "PocketSurfaces"]
+
+__all__ = ["ShapesManager", "SphereShapes", "PocketSurfaces", "LinkShapes"]

--- a/molsysviewer/shapes/links.py
+++ b/molsysviewer/shapes/links.py
@@ -1,0 +1,126 @@
+"""Herramientas para representar enlaces/cilindros personalizados."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+
+class LinkShapes:
+    def __init__(self, view) -> None:
+        self._view = view
+
+    @staticmethod
+    def _to_pair_list(pairs: Iterable[Sequence[int]] | None, expected_len: int = 2) -> list[list[int]]:
+        if pairs is None:
+            return []
+        normalized: list[list[int]] = []
+        for pair in pairs:
+            if len(pair) != expected_len:
+                raise ValueError(f"Cada par debe tener longitud {expected_len}, recibido {len(pair)}")
+            normalized.append([int(pair[0]), int(pair[1])])
+        return normalized
+
+    @staticmethod
+    def _to_coord_pairs(coords: Iterable[Sequence[Sequence[float]]] | None) -> list[list[list[float]]]:
+        if coords is None:
+            return []
+        normalized: list[list[list[float]]] = []
+        for pair in coords:
+            if len(pair) != 2:
+                raise ValueError("Cada entrada de coordinate_pairs debe tener dos puntos (start, end)")
+            start, end = pair
+            if len(start) != 3 or len(end) != 3:
+                raise ValueError("Cada punto debe tener 3 coordenadas (x, y, z)")
+            normalized.append([[float(start[0]), float(start[1]), float(start[2])], [float(end[0]), float(end[1]), float(end[2])]])
+        return normalized
+
+    @staticmethod
+    def _normalize_optional_list(values, n, cast):
+        if values is None:
+            return None
+        if isinstance(values, (str, bytes)):
+            return [cast(values)] * n
+        try:
+            seq = list(values)
+        except TypeError:
+            return [cast(values)] * n
+        if len(seq) not in (1, n):
+            raise ValueError(f"Esperaba 1 o {n} valores, recibido {len(seq)}")
+        if len(seq) == 1:
+            return [cast(seq[0])] * n
+        return [cast(v) for v in seq]
+
+    def add_links(
+        self,
+        *,
+        atom_pairs: Iterable[Sequence[int]] | None = None,
+        coordinate_pairs: Iterable[Sequence[Sequence[float]]] | None = None,
+        radii: float | Sequence[float] = 0.2,
+        colors: int | Sequence[int] = 0x4499ff,
+        pocket_ids: Sequence[int | str] | None = None,
+        chain_ids: Sequence[str] | None = None,
+        color_mode: str = "link",
+        alpha: float = 1.0,
+        radial_segments: int | None = None,
+        tag: str | None = None,
+    ) -> None:
+        """Añade cilindros/barras conectando pares de puntos o de átomos.
+
+        Parameters
+        ----------
+        atom_pairs
+            Pares de índices atómicos (0-based) a conectar. Si se proporciona,
+            se usan las coordenadas actuales de la estructura cargada.
+        coordinate_pairs
+            Lista de pares de coordenadas [[x1, y1, z1], [x2, y2, z2]].
+        radii, colors
+            Escalares o listas (uno por enlace) para radio y color.
+        pocket_ids, chain_ids
+            Identificadores opcionales para colorear por pocket o cadena.
+        color_mode
+            "link" | "pocket" | "chain".
+        alpha
+            Transparencia global (0-1).
+        radial_segments
+            Segmentos radiales del cilindro (>=3). Por defecto 16.
+        tag
+            Etiqueta opcional para el nodo de estado en Mol*.
+        """
+
+        coordinate_pairs_list = self._to_coord_pairs(coordinate_pairs)
+        atom_pairs_list = self._to_pair_list(atom_pairs) if atom_pairs is not None else []
+
+        if not coordinate_pairs_list and not atom_pairs_list:
+            raise ValueError("Debes aportar coordinate_pairs o atom_pairs")
+
+        n_links = len(coordinate_pairs_list) if coordinate_pairs_list else len(atom_pairs_list)
+
+        radii_list = self._normalize_optional_list(radii, n_links, float)
+        colors_list = self._normalize_optional_list(colors, n_links, int)
+        pocket_ids_list = self._normalize_optional_list(pocket_ids, n_links, lambda v: v)
+        chain_ids_list = self._normalize_optional_list(chain_ids, n_links, str)
+
+        options: dict = {
+            "mode": "atom-indices" if atom_pairs_list else "coordinates",
+            "alpha": float(alpha),
+            "color_mode": color_mode,
+        }
+
+        if atom_pairs_list:
+            options["atom_pairs"] = atom_pairs_list
+        if coordinate_pairs_list:
+            options["coordinate_pairs"] = coordinate_pairs_list
+        if radii_list is not None:
+            options["radii"] = radii_list
+        if colors_list is not None:
+            options["colors"] = colors_list
+        if pocket_ids_list is not None:
+            options["pocket_ids"] = pocket_ids_list
+        if chain_ids_list is not None:
+            options["chain_ids"] = chain_ids_list
+        if radial_segments is not None:
+            options["radial_segments"] = int(radial_segments)
+        if tag is not None:
+            options["tag"] = tag
+
+        self._view._send({"op": "add_network_links", "options": options})


### PR DESCRIPTION
## Summary
- add network link mesh builder and state transformer for configurable link cylinders
- wire new network link message handling and options in the widget
- expose Python API helpers for sending atom/coordinate link data with radii and colors

## Testing
- python -m compileall molsysviewer/shapes/links.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922061244a083269c94a49141d73add)