### PR TITLE
Add triangle face rendering support

### DIFF
--- a/molsysviewer/js/src/widget.ts
+++ b/molsysviewer/js/src/widget.ts
@@ -24,9 +24,11 @@ import {
     DisplacementVectorOptions,
     addDisplacementVectorsFromPython,
     addNetworkLinksFromPython,
+    addTriangleFacesFromPython,
     addTransparentSphereFromPython,
     addTransparentSpheresFromPython,
     NetworkLinkOptions,
+    TriangleFacesOptions,
     TransparentSphereSpec,
 } from "./shapes";
 import { addPocketSurfaceFromPython, PocketSurfaceOptions } from "./pocket-surface";
@@ -140,6 +142,9 @@ class MolSysViewerController {
                     break;
                 case "add_displacement_vectors":
                     await this.handleAddDisplacementVectors(msg as AddDisplacementVectorsMessage);
+                    break;
+                case "add_triangle_faces":
+                    await this.handleAddTriangleFaces(msg as AddTriangleFacesMessage);
                     break;
 
                 case "update_visibility":
@@ -285,6 +290,20 @@ class MolSysViewerController {
             await addDisplacementVectorsFromPython(this.plugin, options);
         } catch (err) {
             console.error("[MolSysViewer] Error creando displacement vectors", err);
+        }
+    }
+
+    private async handleAddTriangleFaces(msg: AddTriangleFacesMessage) {
+        const options = msg.options ?? {};
+        if (!options.vertices && !options.atom_triplets && !options.atomTriplets) {
+            console.warn("[MolSysViewer] add_triangle_faces sin vertices ni atom_triplets");
+            return;
+        }
+        try {
+            const ref = await addTriangleFacesFromPython(this.plugin, options);
+            if (ref) this.shapeRefs.add(ref);
+        } catch (err) {
+            console.error("[MolSysViewer] Error creando triangle faces", err);
         }
     }
 
@@ -504,6 +523,11 @@ type AddDisplacementVectorsMessage = {
     options?: DisplacementVectorOptions;
 };
 
+type AddTriangleFacesMessage = {
+    op: "add_triangle_faces";
+    options?: TriangleFacesOptions;
+};
+
 type LoadStructureMessage = {
     op: "load_structure_from_string" | "load_pdb_string";
     data?: string;
@@ -558,6 +582,7 @@ type ViewerMessage =
     AddPocketSurfaceMessage |
     AddNetworkLinksMessage |
     AddDisplacementVectorsMessage |
+    AddTriangleFacesMessage |
     LoadStructureMessage |
     LoadMolSysPayloadMessage |
     LoadStructureFromUrlMessage |

--- a/molsysviewer/shapes/__init__.py
+++ b/molsysviewer/shapes/__init__.py
@@ -4,6 +4,7 @@ from .spheres import SphereShapes
 from .pocket_surfaces import PocketSurfaces
 from .links import LinkShapes
 from .displacements import DisplacementVectors
+from .triangle_faces import TriangleFaces
 
 
 class ShapesManager:
@@ -21,6 +22,7 @@ class ShapesManager:
         self.pockets = PocketSurfaces(view)
         self.links = LinkShapes(view)
         self.vectors = DisplacementVectors(view)
+        self.triangles = TriangleFaces(view)
 
     # Atajos de conveniencia para mantener la API actual:
     #
@@ -72,6 +74,13 @@ class ShapesManager:
     ):
         return self.vectors.add_displacement_vectors(*args, **kwargs)
 
+    def add_triangle_faces(
+        self,
+        *args,
+        **kwargs,
+    ):
+        return self.triangles.add_triangle_faces(*args, **kwargs)
+
 
 __all__ = [
     "ShapesManager",
@@ -79,4 +88,5 @@ __all__ = [
     "PocketSurfaces",
     "LinkShapes",
     "DisplacementVectors",
+    "TriangleFaces",
 ]

--- a/molsysviewer/shapes/triangle_faces.py
+++ b/molsysviewer/shapes/triangle_faces.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+
+class TriangleFaces:
+    def __init__(self, view) -> None:
+        self._view = view
+
+    @staticmethod
+    def _normalize_vertices(vertices: Iterable[Sequence[float]] | None) -> list[list[list[float]]]:
+        if vertices is None:
+            return []
+
+        normalized: list[list[list[float]]] = []
+        for tri in vertices:
+            tri_list = list(tri)
+            if len(tri_list) == 3 and all(isinstance(v, Sequence) and len(v) == 3 for v in tri_list):
+                normalized.append(
+                    [
+                        [float(tri_list[0][0]), float(tri_list[0][1]), float(tri_list[0][2])],
+                        [float(tri_list[1][0]), float(tri_list[1][1]), float(tri_list[1][2])],
+                        [float(tri_list[2][0]), float(tri_list[2][1]), float(tri_list[2][2])],
+                    ]
+                )
+            elif len(tri_list) == 9:
+                normalized.append(
+                    [
+                        [float(tri_list[0]), float(tri_list[1]), float(tri_list[2])],
+                        [float(tri_list[3]), float(tri_list[4]), float(tri_list[5])],
+                        [float(tri_list[6]), float(tri_list[7]), float(tri_list[8])],
+                    ]
+                )
+            else:
+                raise ValueError(
+                    "Cada triángulo debe ser [[x1,y1,z1],[x2,y2,z2],[x3,y3,z3]] o una lista de 9 números"
+                )
+        return normalized
+
+    @staticmethod
+    def _normalize_triplets(atom_triplets: Iterable[Sequence[int]] | None) -> list[list[int]]:
+        if atom_triplets is None:
+            return []
+
+        normalized: list[list[int]] = []
+        for tri in atom_triplets:
+            if len(tri) != 3:
+                raise ValueError("Cada entrada de atom_triplets debe tener 3 índices")
+            normalized.append([int(tri[0]), int(tri[1]), int(tri[2])])
+        return normalized
+
+    @staticmethod
+    def _normalize_optional_list(values, n: int, cast):
+        if values is None:
+            return None
+        if isinstance(values, (str, bytes)):
+            return [cast(values)] * n
+        try:
+            seq = list(values)
+        except TypeError:
+            return [cast(values)] * n
+        if len(seq) not in (1, n):
+            raise ValueError(f"Esperaba 1 o {n} valores, recibido {len(seq)}")
+        if len(seq) == 1:
+            return [cast(seq[0])] * n
+        return [cast(v) for v in seq]
+
+    def add_triangle_faces(
+        self,
+        *,
+        vertices: Iterable[Sequence[float]] | None = None,
+        atom_triplets: Iterable[Sequence[int]] | None = None,
+        colors: int | Sequence[int] = 0xCCCCCC,
+        alpha: float = 1.0,
+        labels: Sequence[str] | str | None = None,
+        tag: str | None = None,
+    ) -> None:
+        """Añade caras triangulares personalizadas usando coordenadas o índices atómicos."""
+
+        vertices_list = self._normalize_vertices(vertices)
+        atom_triplets_list = self._normalize_triplets(atom_triplets)
+
+        if not vertices_list and not atom_triplets_list:
+            raise ValueError("Debes proporcionar vertices o atom_triplets")
+
+        n = len(vertices_list) if vertices_list else len(atom_triplets_list)
+
+        colors_list = self._normalize_optional_list(colors, n, int)
+        labels_list = self._normalize_optional_list(labels, n, str)
+
+        options: dict = {"alpha": float(alpha)}
+
+        if vertices_list:
+            options["vertices"] = vertices_list
+        if atom_triplets_list:
+            options["atom_triplets"] = atom_triplets_list
+        if colors_list is not None:
+            options["colors"] = colors_list
+        if labels_list is not None:
+            options["labels"] = labels_list
+        if tag is not None:
+            options["tag"] = tag
+
+        self._view._send({"op": "add_triangle_faces", "options": options})


### PR DESCRIPTION
## Summary
- add a Mol* triangle face mesh builder with per-triangle colors/labels, alpha control, and support for atom index inputs
- wire the viewer widget to handle add_triangle_faces messages and keep references for cleanup
- expose a Python API via ShapesManager to send triangle face requests from coordinates or atom triplets

## Testing
- python -m compileall molsysviewer


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922148aeecc8326af8329788c9aea38)